### PR TITLE
chore: fix passgen typo from initial setup

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -2,7 +2,7 @@ style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
-  repository_url: https://github.com/Antolius/passgen
+  repository_url: https://github.com/kreuzwerker/m1-terraform-provider-helper
 options:
   commits:
      filters:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -24,5 +24,5 @@
 ## Your Environment
 
 - OS: {Please write here}
-- passgen version: {Please write here}
+- m1-terraform-provider-helper version: {Please write here}
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Thank you for your contribution to passgen! Please replace {Please write here} with your description -->
+<!-- Thank you for your contribution to m1-terraform-provider-helper! Please replace {Please write here} with your description -->
 
 
 ## What does this do / why do we need it?

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@
 
 ### Go ###
 # Binaries for programs and plugins
-passgen
-!cmd/passgen
+m1-terraform-provider-helper
+!cmd/m1-terraform-provider-helper
 *.exe
 *.exe~
 *.dll


### PR DESCRIPTION
<!-- Thank you for your contribution to passgen! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

To fix the copy past typos from the initial setup

## Additional Comments (if any)

see #10 
