### PR TITLE
fix: respect GOPATH environment variable

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -16,6 +16,7 @@ type Config struct {
 	TerraformPluginDir       string
 	TerraformPluginBackupDir string
 	BaseDir                  string
+	GoPath                   string
 	ProvidersCacheDir        string
 }
 
@@ -34,6 +35,7 @@ func New() *App {
 	app := &App{
 		Config: &Config{
 			BaseDir:                  BaseDir,
+			GoPath:                   GetCurrentGoPath(),
 			TerraformPluginDir:       BaseDir + DefaultTerraformPluginDir,
 			TerraformPluginBackupDir: BaseDir + DefaultTerraformPluginBackupDir,
 			ProvidersCacheDir:        BaseDir + DefaultProvidersCacheDir,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -28,7 +28,11 @@ func setupTestAppInstance(t *testing.T) (app.App, *bytes.Buffer) {
 	tmpDir := t.TempDir()
 	buf := new(bytes.Buffer)
 	config := app.Config{
-		tmpDir + "/plugins", tmpDir + "/plugins_backup", tmpDir, tmpDir + "/cliCache",
+		TerraformPluginDir:       tmpDir + "/plugins",
+		TerraformPluginBackupDir: tmpDir + "/plugins_backup",
+		BaseDir:                  tmpDir,
+		GoPath:                   app.GetCurrentGoPath(),
+		ProvidersCacheDir:        tmpDir + "/cliCache",
 	}
 	app := app.App{
 		Config: &config,

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -197,10 +197,10 @@ func (a *App) moveBinaryToCorrectLocation(providerName string, version string, e
 		log.Fatal(err)
 	}
 
-	pathOfExecutable := a.Config.BaseDir + "/go/bin/" + executableName
+	pathOfExecutable := a.Config.GoPath + "/bin/" + executableName
 	newPath := filePath + "/" + executableName + "_" + version + "_x5"
 
-	log.Print("Move from " + pathOfExecutable + "to" + newPath)
+	log.Print("Move from " + pathOfExecutable + " to " + newPath)
 	err = os.Rename(pathOfExecutable, newPath)
 
 	if err != nil {

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -10,5 +10,6 @@ func GetCurrentGoPath() string {
 	if path == "" {
 		path = build.Default.GOPATH
 	}
+
 	return path
 }

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	"go/build"
+	"os"
+)
+
+func GetCurrentGoPath() string {
+	path := os.Getenv("GOPATH")
+	if path == "" {
+		path = build.Default.GOPATH
+	}
+	return path
+}


### PR DESCRIPTION
## What does this do / why do we need it
I ran into the issue that the binary was build in a different location then this tool expects. I am having GOPATH defined in my setup which does currently not work with the tool (see #15 ) 

## How this PR fixes the problem?

Instead of relying on hardcode paths of BaseDir (homeDir) + `/go/bin` we now detect if the GOPATH env variable is set and use this. Otherwise we default back to the system default variable

## What should your reviewer look out for in this PR?

I've only tested this change with `GOPATH` being explicitly set


## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)


## Additional Comments (if any)

{Please write here}


## Which issue(s) does this PR fix?
fixes #15
