### PR TITLE
Fix aws provider build

### DIFF
--- a/internal/app/install_test.go
+++ b/internal/app/install_test.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestExtractVersionAsNumber(t *testing.T) {
+	var number int
+	number = extractMajorVersionAsNumber("v2.34.5")
+	if number != 2 {
+		t.Fatalf("number should be equal 2")
+	}
+	number = extractMajorVersionAsNumber("2.34.5")
+	if number != 2 {
+		t.Fatalf("number should be equal 2")
+	}
+}
+
+func TestCreateBuildCommand(t *testing.T) {
+	var buildCommand string
+	var expectedBuildCommand string
+	buildCommand = createBuildCommand("datadog/datadog", "2.35.9")
+	expectedBuildCommand = "make build"
+	if buildCommand != expectedBuildCommand {
+		t.Fatalf("buildCommand should be equal make build")
+	}
+	buildCommand = createBuildCommand("hashicorp/aws", "v2.71.0")
+	expectedBuildCommand = "make tools && make fmt && gofmt -s -w ./tools.go && make build"
+	if buildCommand != expectedBuildCommand {
+		t.Fatalf("buildCommand2 should be equal make build")
+	}
+	buildCommand = createBuildCommand("hashicorp/aws", "v3.0.0")
+	expectedBuildCommand = "cd tools && go get -d github.com/pavius/impi/cmd/impi && cd .. && make tools && make build"
+	if buildCommand != expectedBuildCommand {
+		t.Fatalf("buildCommand3 should be equal make build")
+	}
+}


### PR DESCRIPTION
## What does this do / why do we need it?

Different verrsions of the same provider have different build commands. Currently it is only possible to have one custo build command per provider


## How this PR fixes the problem?

Makes it possible to add different build commands for different versions of the same providers


## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)


## Which issue(s) does this PR fix?
Fixes #17 