### PR TITLE
fix: Path in .terraform.d should contain normalized version.

### DIFF
--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -165,6 +165,14 @@ func extractMajorVersionAsNumber(version string) int {
 	return number
 }
 
+func normalizeSemver(version string) string {
+	if strings.HasPrefix(version, "v") {
+		return version[1:]
+	}
+
+	return version
+}
+
 func createBuildCommand(providerName string, version string) string {
 	majorVersionNumberAsInt := extractMajorVersionAsNumber(version)
 
@@ -200,6 +208,8 @@ func (a *App) buildProvider(dir string, providerName string, version string) {
 func (a *App) moveBinaryToCorrectLocation(providerName string, version string, executableName string) {
 	if len(version) == 0 {
 		version = "master"
+	} else {
+		version = normalizeSemver(version)
 	}
 
 	filePath := a.Config.TerraformPluginDir + "/registry.terraform.io/" + providerName + "/" + version + "/darwin_arm64"

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -27,6 +27,11 @@ type Provider struct {
 	Description string `json:"description"`
 }
 
+type BuildCommandInformation struct {
+	command         string
+	startingVersion int
+}
+
 func CheckIfError(err error) {
 	if err == nil {
 		return
@@ -176,27 +181,30 @@ func normalizeSemver(version string) string {
 func createBuildCommand(providerName string, version string) string {
 	majorVersionNumberAsInt := extractMajorVersionAsNumber(version)
 
-	buildCommands := make(map[string]map[int]string)
-	buildCommands["default"] = map[int]string{0: "make build"}
-	buildCommands["hashicorp/aws"] = make(map[int]string)
-	buildCommands["hashicorp/aws"][0] = "make tools && make fmt && gofmt -s -w ./tools.go && make build"
-	buildCommands["hashicorp/aws"][3] = "cd tools && go get -d github.com/pavius/impi/cmd/impi && cd .. && make tools && make build"
+	const three = 3
+
+	buildCommands := make(map[string][]BuildCommandInformation)
+	buildCommands["default"] = []BuildCommandInformation{{command: "make build", startingVersion: 0}}
+	buildCommands["hashicorp/aws"] = []BuildCommandInformation{
+		{command: "make tools && make fmt && gofmt -s -w ./tools.go && make build", startingVersion: 0},
+		{command: "cd tools && go get -d github.com/pavius/impi/cmd/impi && cd .. && make tools && make build", startingVersion: three},
+	}
 
 	buildCommandMap, exists := buildCommands[providerName]
 
 	if exists {
-		var foundBuilCommand string
+		var foundBuildCommand string
 
-		for k := range buildCommandMap {
-			if majorVersionNumberAsInt >= k {
-				foundBuilCommand = buildCommands[providerName][k]
+		for _, v := range buildCommandMap {
+			if majorVersionNumberAsInt >= v.startingVersion {
+				foundBuildCommand = v.command
 			}
 		}
 
-		return foundBuilCommand
+		return foundBuildCommand
 	}
 
-	return buildCommands["default"][0]
+	return buildCommands["default"][0].command
 }
 
 func (a *App) buildProvider(dir string, providerName string, version string) {

--- a/internal/app/install_test.go
+++ b/internal/app/install_test.go
@@ -22,16 +22,27 @@ func TestCreateBuildCommand(t *testing.T) {
 	buildCommand = createBuildCommand("datadog/datadog", "2.35.9")
 	expectedBuildCommand = "make build"
 	if buildCommand != expectedBuildCommand {
-		t.Fatalf("buildCommand should be equal make build")
+		t.Fatalf("buildCommand '%s' should be equal '%s'", buildCommand, expectedBuildCommand)
 	}
 	buildCommand = createBuildCommand("hashicorp/aws", "v2.71.0")
 	expectedBuildCommand = "make tools && make fmt && gofmt -s -w ./tools.go && make build"
 	if buildCommand != expectedBuildCommand {
-		t.Fatalf("buildCommand2 should be equal make build")
+		t.Fatalf("buildCommand '%s' should be equal '%s'", buildCommand, expectedBuildCommand)
 	}
 	buildCommand = createBuildCommand("hashicorp/aws", "v3.0.0")
 	expectedBuildCommand = "cd tools && go get -d github.com/pavius/impi/cmd/impi && cd .. && make tools && make build"
 	if buildCommand != expectedBuildCommand {
-		t.Fatalf("buildCommand3 should be equal make build")
+		t.Fatalf("buildCommand '%s' should be equal '%s'", buildCommand, expectedBuildCommand)
+	}
+}
+
+func TestNormalizeSemver(t *testing.T) {
+	version := normalizeSemver("v2.34.5")
+	if version != "2.34.5" {
+		t.Fatalf("version should be equal 2.34.5, not %s", version)
+	}
+	version = normalizeSemver("2.34.5")
+	if version != "2.34.5" {
+		t.Fatalf("version2 should be equal 2.34.5, not %s", version)
 	}
 }


### PR DESCRIPTION
## What does this do / why do we need it?

See issue #20 


## How this PR fixes the problem?

Normalize version (`v2.2.0` -> `2.2.0`) before it is used in path concatenations


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Which issue(s) does this PR fix?
fixes #20 
