### PR TITLE
feat: Pass custom build command to install step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ m1-terraform-provider-helper activate # (In case you have not activated the help
 m1-terraform-provider-helper install hashicorp/vault -v v2.10.0 # Install and compile
 ```
 
+### Providing custom build commands
+
+You can override the built-in build command handling by using the `--custom-build-command` flag.
+
+**Explanation**:
+The `install` commands relies on an internal `buildCommands` map to find the correct build command for an provider. For some important providers we have hardcoded different commands, but the default (and fallback) is `make build`. If that does not work for the provider you want to install, you can also pass a custom build command using the `--custom-build-command` flag.
+
+Please refer to the documentation of the provider to find out the build command.
+
+
 ## Development
 
 ### Testing

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,6 +10,7 @@ import (
 
 func installCmd() *cobra.Command {
 	var versionString string
+
 	var customBuildCommand string
 
 	cmd := &cobra.Command{

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,6 +10,7 @@ import (
 
 func installCmd() *cobra.Command {
 	var versionString string
+	var customBuildCommand string
 
 	cmd := &cobra.Command{
 		Use:   "install [providerName]",
@@ -21,7 +22,7 @@ func installCmd() *cobra.Command {
 			a.Init()
 
 			if a.IsTerraformPluginDirExistent() {
-				a.Install(args[0], versionString)
+				a.Install(args[0], versionString, customBuildCommand)
 			} else {
 				fmt.Fprintln(os.Stdout, "Please activate first")
 			}
@@ -30,6 +31,7 @@ func installCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&versionString, "version", "v", "", "The version of the provider")
+	cmd.Flags().StringVar(&customBuildCommand, "custom-build-command", "", "A custom build command to execute instead of the built-in commands")
 
 	return cmd
 }

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -208,8 +208,14 @@ func createBuildCommand(providerName string, version string, goPath string) stri
 	return buildCommands["default"][0].command
 }
 
-func (a *App) buildProvider(dir string, providerName string, version string) {
-	buildCommand := createBuildCommand(providerName, version, a.Config.GoPath)
+func (a *App) buildProvider(dir string, providerName string, version string, customBuildCommand string) {
+	var buildCommand string
+	if len(customBuildCommand) > 0 {
+		fmt.Fprintf(os.Stdout, "Using custom build command: \"%s\n\"", customBuildCommand)
+		buildCommand = customBuildCommand
+	} else {
+		buildCommand = createBuildCommand(providerName, version, a.Config.GoPath)
+	}
 	// #nosec G204
 	executeBashCommand(buildCommand, a.Config.ProvidersCacheDir+"/"+dir)
 }
@@ -239,7 +245,7 @@ func (a *App) moveBinaryToCorrectLocation(providerName string, version string, e
 	}
 }
 
-func (a *App) Install(providerName string, version string) bool {
+func (a *App) Install(providerName string, version string, customBuildCommand string) bool {
 	providerData := a.getProviderData(providerName)
 	fmt.Fprintf(os.Stdout, "Repo: %s\n", providerData.Repo)
 
@@ -247,7 +253,7 @@ func (a *App) Install(providerName string, version string) bool {
 	fmt.Fprintf(os.Stdout, "GitRepo: %s\n", gitRepo)
 
 	sourceCodeDir := a.checkoutSourceCode(gitRepo, version)
-	a.buildProvider(sourceCodeDir, providerName, version)
+	a.buildProvider(sourceCodeDir, providerName, version, customBuildCommand)
 
 	name := strings.Split(gitRepo, "/")[1]
 	a.moveBinaryToCorrectLocation(providerName, version, name)

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -210,6 +210,7 @@ func createBuildCommand(providerName string, version string, goPath string) stri
 
 func (a *App) buildProvider(dir string, providerName string, version string, customBuildCommand string) {
 	var buildCommand string
+
 	if len(customBuildCommand) > 0 {
 		fmt.Fprintf(os.Stdout, "Using custom build command: \"%s\n\"", customBuildCommand)
 		buildCommand = customBuildCommand


### PR DESCRIPTION


## What does this do / why do we need it?

Provide the possibility to pass in a custom build command. This also mitigates the need to constantly update the `buildCommands` map.


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)



## Which issue(s) does this PR fix?

Fixes #25 
