### PR TITLE
chore(ci): add install integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build a release binary
         run: |
           make build-release
-          m1-terraform-provider-helper activate
+          ./dist/release/m1-terraform-provider-helper activate
       - name: Run integration tests
         run: |
           ./dist/release/m1-terraform-provider-helper install hashicorp/github -v v3.0.0 --custom-build-command "go fmt ./... && make fmt && make build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,21 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./dist/test_results/main/coverage.lcov
+  integration:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Build a release binary
+        run: make build-release
+      - name: Run integration tests
+        run: |
+          ./dist/release/m1-terraform-provider-helper install hashicorp/github -v v3.0.0 --custom-build-command "go fmt ./... && make fmt && make build"
+          ./dist/release/m1-terraform-provider-helper install hashicorp/random -v v3.1.0 --custom-build-command "go fmt ./... && make build"
+          ./dist/release/m1-terraform-provider-helper install mongodb/mongodbatlas -v v0.8.2 --custom-build-command "go fmt ./... && make build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,5 @@ jobs:
       - name: Run integration tests
         run: |
           ./dist/release/m1-terraform-provider-helper install hashicorp/github -v v3.0.0 --custom-build-command "go fmt ./... && make fmt && make build"
-          ./dist/release/m1-terraform-provider-helper install hashicorp/random -v v3.1.0 --custom-build-command "go fmt ./... && make build"
+          ./dist/release/m1-terraform-provider-helper install hashicorp/random -v v3.1.0 --custom-build-command "gofmt -s -w tools && make build"
           ./dist/release/m1-terraform-provider-helper install mongodb/mongodbatlas -v v0.8.2 --custom-build-command "go fmt ./... && make build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,9 @@ jobs:
         with:
           go-version: 1.17
       - name: Build a release binary
-        run: make build-release
+        run: |
+          make build-release
+          m1-terraform-provider-helper activate
       - name: Run integration tests
         run: |
           ./dist/release/m1-terraform-provider-helper install hashicorp/github -v v3.0.0 --custom-build-command "go fmt ./... && make fmt && make build"

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -130,7 +130,7 @@ func (a *App) cloneRepo(gitURL string) {
 func (a *App) checkoutSourceCode(gitURL string, version string) string {
 	var r *git.Repository
 
-	repoDir := extractRepoNameFromUrl(gitURL)
+	repoDir := extractRepoNameFromURL(gitURL)
 	path := a.Config.ProvidersCacheDir + "/" + repoDir
 
 	if !a.isDirExistent(path) {
@@ -161,8 +161,9 @@ func (a *App) checkoutSourceCode(gitURL string, version string) string {
 	return repoDir
 }
 
-func extractRepoNameFromUrl(url string) string {
+func extractRepoNameFromURL(url string) string {
 	parts := strings.Split(url, "/")
+
 	return parts[len(parts)-1]
 }
 

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -130,7 +130,7 @@ func (a *App) cloneRepo(gitURL string) {
 func (a *App) checkoutSourceCode(gitURL string, version string) string {
 	var r *git.Repository
 
-	repoDir := strings.Split(gitURL, "/")[1]
+	repoDir := extractRepoNameFromUrl(gitURL)
 	path := a.Config.ProvidersCacheDir + "/" + repoDir
 
 	if !a.isDirExistent(path) {
@@ -159,6 +159,11 @@ func (a *App) checkoutSourceCode(gitURL string, version string) string {
 	}
 
 	return repoDir
+}
+
+func extractRepoNameFromUrl(url string) string {
+	parts := strings.Split(url, "/")
+	return parts[len(parts)-1]
 }
 
 func extractMajorVersionAsNumber(version string) int {
@@ -250,7 +255,7 @@ func (a *App) Install(providerName string, version string, customBuildCommand st
 	providerData := a.getProviderData(providerName)
 	fmt.Fprintf(os.Stdout, "Repo: %s\n", providerData.Repo)
 
-	gitRepo := strings.Replace(providerData.Repo, "https://github.com/", "git@github.com:", 1)
+	gitRepo := providerData.Repo
 	fmt.Fprintf(os.Stdout, "GitRepo: %s\n", gitRepo)
 
 	sourceCodeDir := a.checkoutSourceCode(gitRepo, version)

--- a/internal/app/install_test.go
+++ b/internal/app/install_test.go
@@ -46,3 +46,14 @@ func TestNormalizeSemver(t *testing.T) {
 		t.Fatalf("version2 should be equal 2.34.5, not %s", version)
 	}
 }
+
+func TestExtractRepoNameFromUrl(t *testing.T) {
+	repoDir := extractRepoNameFromUrl("https://github.com/hashicorp/terraform-provider-github")
+	if repoDir != "terraform-provider-github" {
+		t.Fatalf("repoDir should be equal terraform-provider-github, not %s", repoDir)
+	}
+	repoDir = extractRepoNameFromUrl("git@github.com:hashicorp/terraform-provider-github")
+	if repoDir != "terraform-provider-github" {
+		t.Fatalf("repoDir should be equal terraform-provider-github, not %s", repoDir)
+	}
+}

--- a/internal/app/install_test.go
+++ b/internal/app/install_test.go
@@ -48,11 +48,11 @@ func TestNormalizeSemver(t *testing.T) {
 }
 
 func TestExtractRepoNameFromUrl(t *testing.T) {
-	repoDir := extractRepoNameFromUrl("https://github.com/hashicorp/terraform-provider-github")
+	repoDir := extractRepoNameFromURL("https://github.com/hashicorp/terraform-provider-github")
 	if repoDir != "terraform-provider-github" {
 		t.Fatalf("repoDir should be equal terraform-provider-github, not %s", repoDir)
 	}
-	repoDir = extractRepoNameFromUrl("git@github.com:hashicorp/terraform-provider-github")
+	repoDir = extractRepoNameFromURL("git@github.com:hashicorp/terraform-provider-github")
 	if repoDir != "terraform-provider-github" {
 		t.Fatalf("repoDir should be equal terraform-provider-github, not %s", repoDir)
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to m1-terraform-provider-helper! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

- a proposal outline for testing `install` until we do not have unit tests
- need to remove the Token to be able to git clone the repo of a provider


## How this PR fixes the problem?

adds the actual tests from #25 


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)
