### PR TITLE
fix(src): Parse correct binary name from repo url.

### DIFF
--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -245,7 +245,7 @@ func (a *App) Install(providerName string, version string, customBuildCommand st
 	sourceCodeDir := checkoutSourceCode(a.Config.ProvidersCacheDir, gitRepo, version)
 	a.buildProvider(sourceCodeDir, providerName, version, customBuildCommand)
 
-	name := strings.Split(gitRepo, "/")[1]
+	name := extractRepoNameFromURL(gitRepo)
 	a.moveBinaryToCorrectLocation(providerName, version, name)
 
 	return true


### PR DESCRIPTION
## What does this do / why do we need it?

Final binaries are named wrong


## How this PR fixes the problem?

Correctly parse the name of the binary


## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)


## Additional Comments (if any)

{Please write here}


## Which issue(s) does this PR fix?

fixes #34
