### PR TITLE
Fix build command for version 2.x of AWS provider

### DIFF
--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -176,7 +176,7 @@ func createBuildCommand(providerName string, version string, goPath string) stri
 	buildCommands["default"] = []BuildCommandInformation{{command: "make build", startingVersion: 0}}
 	buildCommands["hashicorp/helm"] = []BuildCommandInformation{{command: "make build && cp terraform-provider-helm " + goPath + "/bin/" + "terraform-provider-helm", startingVersion: 0}}
 	buildCommands["hashicorp/aws"] = []BuildCommandInformation{
-		{command: "make tools && make fmt && gofmt -s -w ./tools.go && make build", startingVersion: 0},
+		{command: "go get -u golang.org/x/sys && make tools && make fmt && gofmt -s -w ./tools.go && make build", startingVersion: 0},
 		{command: "cd tools && go get -d github.com/pavius/impi/cmd/impi && cd .. && make tools && make build", startingVersion: three},
 	}
 


### PR DESCRIPTION
Underlying issue: https://github.com/golang/go/issues/51706

<!-- Thank you for your contribution to m1-terraform-provider-helper! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

This fixes the install of the AWS provider 2.x due to a bug in Go sys module


## How this PR fixes the problem?

Updates the sys module before running the various build commands, only for the command used to compile the AWS provider


## What should your reviewer look out for in this PR?

N/A


## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)



## Which issue(s) does this PR fix?

N/A