### PR TITLE
ci: add aws v1.3.0 integration test build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,4 @@ jobs:
           ./dist/release/m1-terraform-provider-helper install hashicorp/github -v v3.0.0 --custom-build-command "go fmt ./... && make fmt && make build"
           ./dist/release/m1-terraform-provider-helper install hashicorp/random -v v3.1.0 --custom-build-command "gofmt -s -w tools && make build"
           ./dist/release/m1-terraform-provider-helper install mongodb/mongodbatlas -v v0.8.2 --custom-build-command "go fmt ./... && make build"
+          ./dist/release/m1-terraform-provider-helper install hashicorp/aws -v v1.3.0 --custom-build-command "make fmt && make build"


### PR DESCRIPTION
<!-- Thank you for your contribution to m1-terraform-provider-helper! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

fixes the build of aws provider v1.3.0


## How this PR fixes the problem?

first by adding a test


## Check lists

* [ ] Test passed
* [x] Coding style (indentation, etc)


## Which issue(s) does this PR fix?
- #40 
