### PR TITLE
docs(readme): add tf, xw logo and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
+<a href="https://terraform.io">
+    <img src="https://raw.githubusercontent.com/kreuzwerker/m1-terraform-provider-helper/main/assets/terraform-logo.png" alt="Terraform logo" title="Terraform" align="right" height="100" />
+</a>
+<a href="https://kreuzwerker.de">
+    <img src="https://raw.githubusercontent.com/kreuzwerker/m1-terraform-provider-helper/main/assets/xw-logo.png" alt="Kreuzwerker logo" title="Kreuzwerker" align="right" height="100" />
+</a>
+
 # m1-terraform-provider-helper
+
+[![Release](https://img.shields.io/github/v/release/kreuzwerker/m1-terraform-provider-helper)](https://github.com/kreuzwerker/m1-terraform-provider-helper/releases)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kreuzwerker/m1-terraform-provider-helper/blob/main/LICENSE)  
+[![Go Status](https://github.com/kreuzwerker/m1-terraform-provider-helper/workflows/tests/badge.svg)](https://github.com/kreuzwerker/m1-terraform-provider-helper/actions)
+[![Lint Status](https://github.com/kreuzwerker/m1-terraform-provider-helper/workflows/golangci-lint/badge.svg)](https://github.com/kreuzwerker/m1-terraform-provider-helper/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kreuzwerker/m1-terraform-provider-helper)](https://goreportcard.com/report/github.com/kreuzwerker/m1-terraform-provider-helper)  
 
 A CLI to help with managing the installation and compilation of terraform providers when running a new M1 Mac. 
 


### PR DESCRIPTION
## What does this do / why do we need it?

To align with https://github.com/kreuzwerker/terraform-provider-docker. Please take a look at the [README](https://github.com/kreuzwerker/m1-terraform-provider-helper/tree/chore/add-logos) of this branch.

## How this PR fixes the problem?

- add tf and xw logo
- adding badges to the readme

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

This helps aligning our branding
