### PR TITLE
Add build commands for google and aws_v4 provider.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,3 @@ jobs:
           ./dist/release/m1-terraform-provider-helper install hashicorp/github -v v3.0.0 --custom-build-command "go fmt ./... && make fmt && make build"
           ./dist/release/m1-terraform-provider-helper install hashicorp/random -v v3.1.0 --custom-build-command "gofmt -s -w tools && make build"
           ./dist/release/m1-terraform-provider-helper install mongodb/mongodbatlas -v v0.8.2 --custom-build-command "go fmt ./... && make build"
-          ./dist/release/m1-terraform-provider-helper install hashicorp/aws -v v1.3.0 --custom-build-command "go mod init && go mod vendor && make fmt && make build"

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -19,6 +19,8 @@ import (
 )
 
 const requestTimeoutSeconds int = 2
+const three int = 3
+const four int = 4
 
 type Provider struct {
 	Repo        string `json:"source"`
@@ -170,14 +172,14 @@ func normalizeSemver(version string) string {
 func createBuildCommand(providerName string, version string, goPath string) string {
 	majorVersionNumberAsInt := extractMajorVersionAsNumber(version)
 
-	const three = 3
-
 	buildCommands := make(map[string][]BuildCommandInformation)
 	buildCommands["default"] = []BuildCommandInformation{{command: "make build", startingVersion: 0}}
 	buildCommands["hashicorp/helm"] = []BuildCommandInformation{{command: "make build && cp terraform-provider-helm " + goPath + "/bin/" + "terraform-provider-helm", startingVersion: 0}}
+	buildCommands["hashicorp/google"] = []BuildCommandInformation{{command: "gofmt -s -w ./tools.go  && make build", startingVersion: 0}}
 	buildCommands["hashicorp/aws"] = []BuildCommandInformation{
 		{command: "make tools && make fmt && gofmt -s -w ./tools.go && make build", startingVersion: 0},
 		{command: "cd tools && go get -d github.com/pavius/impi/cmd/impi && cd .. && make tools && make build", startingVersion: three},
+		{command: "make tools && make build", startingVersion: four},
 	}
 
 	buildCommandMap, exists := buildCommands[providerName]


### PR DESCRIPTION
## What does this do / why do we need it?

Adds new build commands to the built-in matrix:

- google provider (as reported from https://github.com/kreuzwerker/m1-terraform-provider-helper/issues/44)
- aws provider starting with version 4 (https://github.com/kreuzwerker/m1-terraform-provider-helper/issues/37)

## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)