### PR TITLE
Implement version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Available Commands:
   install     Downloads (and compiles) a terraform provider for the M1 chip
   list        Lists all available providers and their versions
   status      Shows the status of the m1 provider installations
+  version     Display the current version
 
 Flags:
   -h, --help   help for m1-terraform-provider-helper
@@ -87,6 +88,8 @@ make build
 in the project's root directory. This will generate the executable `dist/m1-terraform-provider-helper` file that you can run.
 
 ### Release
+
+**IMPORTANT**: Before releasing any version, you have to manually edit the `cmd/version.go` file and change the `version` constant to the new version you'll release.
 
 If you want to generate the changelog and see it only (it will neither commit, tag nor push)
 run one of the following commands:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ func RootCmd() *cobra.Command {
 		deactivateCmd(),
 		installCmd(),
 		listCmd(),
+		versionCmd(),
 	)
 
 	return cmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"fmt"
+	"os"
+)
+
+const version string = "0.5.1"
+
+func versionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Displays the current version",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintf(os.Stdout, "Current version: %s", version)
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"fmt"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 const version string = "0.5.1"


### PR DESCRIPTION
## What does this do / why do we need it?

Gives users the possibility to print the current version of the `m1-terraform-provider-helper`.


## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)



## Which issue(s) does this PR fix?


fixes #42 