### PR TITLE
fix(src): Update local provider repo on install.

### DIFF
--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -124,6 +124,8 @@ func checkoutSourceCode(baseDir string, gitURL string, version string) string {
 
 	// Clean the repository
 	executeBashCommand("git reset --hard && git clean -d -f -q", fullPath)
+	log.Println("Pulling newest changes from " + gitURL)
+	executeBashCommand("git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@' | xargs git checkout && git pull", fullPath)
 
 	if len(version) > 0 {
 		log.Println("version: " + version)
@@ -133,8 +135,7 @@ func checkoutSourceCode(baseDir string, gitURL string, version string) string {
 		})
 		CheckIfError(err)
 	} else {
-		log.Println("No version specified, pulling and checking out main branch")
-		executeBashCommand("git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@' | xargs git checkout && git pull", fullPath)
+		log.Println("No version specified, staying on latest commit")
 	}
 
 	return repoDir


### PR DESCRIPTION
## What does this do / why do we need it?

The issue is the following:

* when we `install` any version of a provider for the first time, we checkout the repo and, thus, have the newest changes at that point in time (let's call it `p1`)
* Now after a few weeks, we want to build another version of the provider. If the release of this version is **newer** than `p1`, we are unable to build that version, because we have not pulled the changes after `p1`



## How this PR fixes the problem?

Solution: At every `install` we pull all newest changes since the last pull 🤷 

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Which issue(s) does this PR fix?


fixes #61 

