### PR TITLE
deps: Update versions in Makefile and Github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.38.0
+          version: v1.46.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run tests
         run: make test
       - name: Convert coverage
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Build a release binary
         run: |
           make build-release

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,3 +15,5 @@ linters:
     - funlen
     - exhaustivestruct
     - goerr113 # will be addressed later
+    - varnamelen
+    - exhaustruct

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ TEST_FORMAT = short-verbose
 endif
 
 # Dependency versions
-GOTESTSUM_VERSION = 1.7.0
-GOLANGCI_VERSION = 1.38.0
+GOTESTSUM_VERSION = 1.8.1
+GOLANGCI_VERSION = 1.46.2
 GITCHGLOG_VERSION = 0.15.1
 
-GOLANG_VERSION = 1.17
+GOLANG_VERSION = 1.18
 
 # Add the ability to override some variables
 # Use with care
@@ -104,7 +104,7 @@ bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
 	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
 bin/golangci-lint-${GOLANGCI_VERSION}:
 	@mkdir -p bin
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINARY=golangci-lint bash -s -- v${GOLANGCI_VERSION}
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINARY=golangci-lint bash -s -- v${GOLANGCI_VERSION}
 	@mv bin/golangci-lint $@
 
 .PHONY: lint

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,7 @@ const (
 	DefaultProvidersCacheDir        = "/.m1-terraform-provider-helper"
 	DefaultTerraformPluginDir       = "/.terraform.d/plugins"
 	DefaultTerraformPluginBackupDir = "/.terraform.d/plugins_backup"
+	FileModePerm                    = 0777
 )
 
 func New() *App {
@@ -54,7 +55,7 @@ func (a *App) Init() {
 
 func createDirIfNotExists(dir string) {
 	if !isDirExistent(dir) {
-		err := os.MkdirAll(dir, 0777)
+		err := os.MkdirAll(dir, FileModePerm)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -125,8 +126,8 @@ func visit(providerVersions map[string][]string) filepath.WalkFunc {
 
 			if exists {
 				// add version to existing entry
-				newEntry := append(entry, version)
-				providerVersions[providerName] = newEntry
+				entry := append(entry, version)
+				providerVersions[providerName] = entry
 			} else {
 				// make new entry
 				newEntry := []string{version}

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -221,18 +221,14 @@ func (a *App) moveBinaryToCorrectLocation(providerName string, version string, e
 	}
 
 	filePath := a.Config.TerraformPluginDir + "/registry.terraform.io/" + providerName + "/" + version + "/darwin_arm64"
-	err := os.MkdirAll(filePath, 0777)
-
-	if err != nil {
-		log.Fatal(err)
-	}
+	createDirIfNotExists(filePath)
 
 	fmt.Fprintf(os.Stdout, "GOPATH: %s\n", a.Config.GoPath)
 	pathOfExecutable := a.Config.GoPath + "/bin/" + executableName
 	newPath := filePath + "/" + executableName + "_" + version + "_x5"
 
 	log.Print("Move from " + pathOfExecutable + " to " + newPath)
-	err = os.Rename(pathOfExecutable, newPath)
+	err := os.Rename(pathOfExecutable, newPath)
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## What does this do / why do we need it?

Updates all used tool versions.
Updates go to use `1.18`

## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)

## Which issue(s) does this PR fix?

fixes #69 
