### PR TITLE
feat: Implement parsing of provider build output.

### DIFF
--- a/internal/app/install_test.go
+++ b/internal/app/install_test.go
@@ -121,3 +121,19 @@ func TestCheckoutSourceCode(t *testing.T) {
 		checkoutSourceCode(tmpDir+"/cliCache", "https://github.com/hashicorp/terraform-provider-random", "v2.2.0")
 	})
 }
+
+func TestParseBuildOutputAndGetBinaryOutputPath(t *testing.T) {
+	t.Run("Should parse correct output from go build -o command", func(t *testing.T) {
+		expected := "build/darwin_arm64/terraform-provider-pingdom_v1.1.3"
+		actual, ok := parseBuildOutputAndGetBinaryOutputPath("go build -o build/darwin_arm64/terraform-provider-pingdom_v1.1.3 ")
+		if ok && expected != actual {
+			t.Fatalf("expected %#v, but got %#v", expected, actual)
+		}
+	})
+	t.Run("Should parse correct output from go install command", func(t *testing.T) {
+		_, ok := parseBuildOutputAndGetBinaryOutputPath("go install")
+		if ok {
+			t.Fatalf("expected ok to be false")
+		}
+	})
+}


### PR DESCRIPTION
## What does this do / why do we need it?

Some providers use `go build -o` to place the final binary somewhere different than the usual `$GOPATH/bin` location. Until now we assumed that every provider binary is placed at the `$GOPATH/bin` location. This is not the case for https://github.com/russellcardullo/terraform-provider-pingdom


## How this PR fixes the problem?

Parse the build output to see if there is a `go build -o` directive used somewhere.



## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)



## Which issue(s) does this PR fix?


fixes #81 
fixes #2 
