### PR TITLE
feat: Implement customizable request timeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A CLI to help with managing the installation and compilation of terraform provid
     - [Terraform Lockfile handling](#terraform-lockfile-handling)
     - [Providing custom build commands](#providing-custom-build-commands)
     - [Logging](#logging)
+    - [Timeouts](#timeouts)
   - [Development](#development)
     - [Testing](#testing)
     - [Build](#build)
@@ -103,6 +104,10 @@ Please refer to the documentation of the provider to find out the build command.
 ### Logging
 
 You can enable additional log output by setting the `TF_HELPER_LOG` environment variable to `info` or `debug` log level.
+
+### Timeouts
+
+The `m1-terraform-provider-helper` does make HTTP calls to the terraform provider registry. The default timeout is 10 seconds. You can change that timeout by using the `TF_HELPER_REQUEST_TIMEOUT` environment variable. For example `TF_HELPER_REQUEST_TIMEOUT=15` for a timeout of 15 seconds.
 
 ## Development
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -20,6 +21,7 @@ type Config struct {
 	BaseDir                  string
 	GoPath                   string
 	ProvidersCacheDir        string
+	RequestTimeoutInSeconds  int
 }
 
 const (
@@ -27,6 +29,7 @@ const (
 	DefaultTerraformPluginDir       = "/.terraform.d/plugins"
 	DefaultTerraformPluginBackupDir = "/.terraform.d/plugins_backup"
 	FileModePerm                    = 0777
+	DefaultRequestTimeoutInSeconds  = 10
 )
 
 func New() *App {
@@ -45,6 +48,18 @@ func New() *App {
 		},
 		Out: os.Stdout,
 	}
+
+	rawValue, ok := os.LookupEnv("TF_HELPER_REQUEST_TIMEOUT")
+	value := DefaultRequestTimeoutInSeconds
+
+	if ok {
+		value, err = strconv.Atoi(rawValue)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	app.Config.RequestTimeoutInSeconds = value
 
 	return app
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 type App struct {
@@ -55,7 +57,7 @@ func New() *App {
 	if ok {
 		value, err = strconv.Atoi(rawValue)
 		if err != nil {
-			log.Fatal(err)
+			logrus.Fatalf("Error while trying to parse TF_HELPER_REQUEST_TIMEOUT. It should be a simple integer. Error: %v", err.Error())
 		}
 	}
 

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -20,8 +20,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const requestTimeoutSeconds int = 2
-
 type Provider struct {
 	Repo        string `json:"source"`
 	Description string `json:"description"`
@@ -71,10 +69,10 @@ func executeBashCommand(command string, baseDir string) string {
 	return string(output)
 }
 
-func getProviderData(providerName string) (Provider, error) {
+func getProviderData(providerName string, requestTimeoutInSeconds int) (Provider, error) {
 	url := "https://registry.terraform.io/v1/providers/" + providerName
 
-	client := &http.Client{Timeout: time.Second * time.Duration(float64(requestTimeoutSeconds))}
+	client := &http.Client{Timeout: time.Second * time.Duration(float64(requestTimeoutInSeconds))}
 	ctx := context.Background()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 
@@ -308,7 +306,7 @@ func getTerraformVersion() *goversion.Version {
 func (a *App) Install(providerName string, version string, customBuildCommand string) bool {
 	fmt.Fprintf(a.Out, "Getting provider data from terraform registry\n")
 
-	providerData, err := getProviderData(providerName)
+	providerData, err := getProviderData(providerName, a.Config.RequestTimeoutInSeconds)
 
 	if err != nil {
 		logrus.Fatalf("Error while trying to get provider data from terraform registry: %v", err.Error())

--- a/internal/app/install_test.go
+++ b/internal/app/install_test.go
@@ -71,7 +71,7 @@ func TestGetProviderData(t *testing.T) {
 		httpmock.RegisterResponder("GET", "https://registry.terraform.io/v1/providers/"+provider,
 			httpmock.NewStringResponder(200, `{"description": "`+description+`",
 			"source": "`+repo+`"}`))
-		providerData, err := getProviderData(provider)
+		providerData, err := getProviderData(provider, 2)
 		if err != nil {
 			t.Errorf("Should not have an error %s ", err)
 		}
@@ -89,7 +89,7 @@ func TestGetProviderData(t *testing.T) {
 		httpmock.RegisterResponder("GET", "https://registry.terraform.io/v1/providers/"+provider,
 			httpmock.NewStringResponder(200, `{"description": "`+description+`",
 			"source": "`+repo+`"}`).Delay(3*time.Second))
-		_, err := getProviderData(provider)
+		_, err := getProviderData(provider, 2)
 		if !strings.HasPrefix(err.Error(), "timeout error") {
 			t.Errorf("Expected \"error timeout\" but got %#v", err.Error())
 		}
@@ -103,7 +103,7 @@ func TestGetProviderData(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("GET", "https://registry.terraform.io/v1/providers/"+provider,
 			httpmock.NewStringResponder(200, `{"test:"812}`))
-		_, err := getProviderData(provider)
+		_, err := getProviderData(provider, 2)
 		if err == nil {
 			t.Error("Should run into JSON parse error")
 		}


### PR DESCRIPTION
## What does this do / why do we need it?

People keep opening issues when the HTTP request times out. The timeout was 2 seconds. Now increased to 10 seconds and implemented the possibility to change the timeout value via environment variable.
