### PR TITLE
feat: CLI argument for custom registry URL was introduced

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -24,8 +24,12 @@ func installCmd() *cobra.Command {
 			a := app.New()
 			a.Init()
 
+			if customTerraformRegistryURL != "" {
+				a.SetTerraformRegistryURL(customTerraformRegistryURL)
+			}
+
 			if a.IsTerraformPluginDirExistent() {
-				a.Install(args[0], versionString, customBuildCommand, customTerraformRegistryURL)
+				a.Install(args[0], versionString, customBuildCommand)
 			} else {
 				fmt.Fprintln(os.Stdout, "Please activate first")
 			}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,6 +23,7 @@ type Config struct {
 	BaseDir                  string
 	GoPath                   string
 	ProvidersCacheDir        string
+	TerraformRegistryURL     string
 	RequestTimeoutInSeconds  int
 }
 
@@ -30,6 +31,7 @@ const (
 	DefaultProvidersCacheDir        = "/.m1-terraform-provider-helper"
 	DefaultTerraformPluginDir       = "/.terraform.d/plugins"
 	DefaultTerraformPluginBackupDir = "/.terraform.d/plugins_backup"
+	DefaultTerraformRegistryURL     = "https://registry.terraform.io/v1/providers/"
 	FileModePerm                    = 0777
 	DefaultRequestTimeoutInSeconds  = 10
 )
@@ -47,6 +49,7 @@ func New() *App {
 			TerraformPluginDir:       BaseDir + DefaultTerraformPluginDir,
 			TerraformPluginBackupDir: BaseDir + DefaultTerraformPluginBackupDir,
 			ProvidersCacheDir:        BaseDir + DefaultProvidersCacheDir,
+			TerraformRegistryURL:     DefaultTerraformRegistryURL,
 		},
 		Out: os.Stdout,
 	}
@@ -176,4 +179,8 @@ func (a *App) ListProviders() {
 	for k, v := range providerVersions {
 		fmt.Fprintf(a.Out, "%s -> %s\n", k, strings.Join(v, ", "))
 	}
+}
+
+func (a *App) SetTerraformRegistryURL(url string) {
+	a.Config.TerraformRegistryURL = url
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -33,6 +33,7 @@ func setupTestAppInstance(t *testing.T) (app.App, *bytes.Buffer) {
 		BaseDir:                  tmpDir,
 		GoPath:                   app.GetCurrentGoPath(),
 		ProvidersCacheDir:        tmpDir + "/cliCache",
+		TerraformRegistryURL:     app.DefaultTerraformRegistryURL,
 	}
 	app := app.App{
 		Config: &config,

--- a/internal/app/install_test.go
+++ b/internal/app/install_test.go
@@ -71,7 +71,7 @@ func TestGetProviderData(t *testing.T) {
 		httpmock.RegisterResponder("GET", "https://registry.terraform.io/v1/providers/"+provider,
 			httpmock.NewStringResponder(200, `{"description": "`+description+`",
 			"source": "`+repo+`"}`))
-		providerData, err := getProviderData(provider, 2, "")
+		providerData, err := getProviderData(provider, 2, DefaultTerraformRegistryURL)
 		if err != nil {
 			t.Errorf("Should not have an error %s ", err)
 		}
@@ -89,7 +89,7 @@ func TestGetProviderData(t *testing.T) {
 		httpmock.RegisterResponder("GET", "https://registry.terraform.io/v1/providers/"+provider,
 			httpmock.NewStringResponder(200, `{"description": "`+description+`",
 			"source": "`+repo+`"}`).Delay(3*time.Second))
-		_, err := getProviderData(provider, 2, "")
+		_, err := getProviderData(provider, 2, DefaultTerraformRegistryURL)
 		if !strings.HasPrefix(err.Error(), "timeout error") {
 			t.Errorf("Expected \"error timeout\" but got %#v", err.Error())
 		}
@@ -103,7 +103,7 @@ func TestGetProviderData(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("GET", "https://registry.terraform.io/v1/providers/"+provider,
 			httpmock.NewStringResponder(200, `{"test:"812}`))
-		_, err := getProviderData(provider, 2, "")
+		_, err := getProviderData(provider, 2, DefaultTerraformRegistryURL)
 		if err == nil {
 			t.Error("Should run into JSON parse error")
 		}


### PR DESCRIPTION
<!-- Thank you for your contribution to m1-terraform-provider-helper! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

Sometimes it is necessary to override default terraform registry with other registry. This PR introduces new CLI argument to do it.

## How this PR fixes the problem?

PR introduces argument `custom-terraform-registry-url` (or `-u`) which can override default terraform registry URL and use provided instead.


## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)


