### PR TITLE
fix: Typo in install long command output

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -18,8 +18,8 @@ func installCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install [providerName]",
 		Args:  cobra.ExactArgs(1),
-		Short: "Downloads (and compiles) a terraform provider for the M1 chip",
-		Long:  "Download and compiles the specifiec terraform provider for your M1 chip. Provider name is the terraform registry identifier, e.g. \"hashicorp/aws\"",
+		Short: "Downloads (and compiles) a Terraform provider for the M1 chip",
+		Long:  "Download and compiles the specific Terraform provider for your M1 chip. Provider name is the Terraform registry identifier, e.g. \"hashicorp/aws\"",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := app.New()
 			a.Init()
@@ -39,7 +39,7 @@ func installCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&versionString, "version", "v", "", "The version of the provider")
 	cmd.Flags().StringVar(&customBuildCommand, "custom-build-command", "", "A custom build command to execute instead of the built-in commands")
-	cmd.Flags().StringVarP(&customTerraformRegistryURL, "custom-terraform-registry-url", "u", "", "A custom URL of terraform registry")
+	cmd.Flags().StringVarP(&customTerraformRegistryURL, "custom-terraform-registry-url", "u", "", "A custom URL of Terraform registry")
 
 	return cmd
 }

--- a/cmd/lockfile-upgrade.go
+++ b/cmd/lockfile-upgrade.go
@@ -12,7 +12,7 @@ func lockfileUpgradeCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "upgrade",
-		Short: "Upgrades the hashes in a terraform lockfile",
+		Short: "Upgrades the hashes in a Terraform lockfile",
 		Long:  "",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := app.New()

--- a/cmd/lockfile.go
+++ b/cmd/lockfile.go
@@ -7,7 +7,7 @@ import (
 func lockfileCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lockfile",
-		Short: "Commands to work with terraform lockfiles",
+		Short: "Commands to work with Terraform lockfiles",
 	}
 
 	cmd.AddCommand(lockfileUpgradeCmd())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ import (
 func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "m1-terraform-provider-helper",
-		Short: "A CLI to manage the installation of terraform providers for the Mac M1 chip",
+		Short: "A CLI to manage the installation of Terraform providers for the Mac M1 chip",
 	}
 
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Signed-off-by: Adam Harvey <adaharve@cisco.com>

<!-- Thank you for your contribution to m1-terraform-provider-helper! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

Identified a typo for `specific` in the install command.  Fixed that, and while I was here, just capitalized Terraform as a product name in a few places.

## How this PR fixes the problem?

Improves quality.

## What should your reviewer look out for in this PR?

Spelling.


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

```shell
make test-functional
curl -L https://github.com/gotestyourself/gotestsum/releases/download/v1.8.1/gotestsum_1.8.1_darwin_amd64.tar.gz | tar -zOxf - gotestsum > ./bin/gotestsum-1.8.1 && chmod +x ./bin/gotestsum-1.8.1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2014k  100 2014k    0     0  3032k      0 --:--:-- --:--:-- --:--:-- 3032k
bin/gotestsum --no-summary=skipped --junitfile dist/test_results/functional/results.xml --jsonfile dist/test_results/functional/results.out --format short-verbose -- -timeout 1m -coverprofile=dist/test_results/functional/coverage.out -covermode atomic -failfast -race -run ^.*$ ./...
EMPTY cmd
EMPTY cmd/m1-terraform-provider-helper
PASS internal/app.TestCreateBuildCommand (0.00s)
PASS internal/app.TestNormalizeSemver (0.00s)
PASS internal/app.TestExtractRepoNameFromUrl (0.00s)
PASS internal/app.TestCloneRepo (13.07s)
PASS internal/app.TestGetProviderData/Should_get_and_parse_JSON_response (0.00s)
PASS internal/app.TestGetProviderData/Should_get_request_timeout_error (2.00s)
PASS internal/app.TestGetProviderData/Should_error_with_mismatched_JSON (0.00s)
PASS internal/app.TestGetProviderData (2.00s)
PASS internal/app.TestCheckoutSourceCode/Should_checkout_source_code_once (17.21s)
PASS internal/app.TestCheckoutSourceCode/Should_checkout_two_versions_of_same_source_code_once (23.00s)
PASS internal/app.TestCheckoutSourceCode (40.21s)
PASS internal/app.TestParseBuildOutputAndGetBinaryOutputPath/Should_parse_correct_output_from_go_build_-o_command (0.00s)
PASS internal/app.TestParseBuildOutputAndGetBinaryOutputPath/Should_parse_correct_output_from_go_install_command (0.00s)
PASS internal/app.TestParseBuildOutputAndGetBinaryOutputPath (0.00s)
PASS internal/app.TestCreateHclBody/Should_create_body_with_one_entry (0.00s)
PASS internal/app.TestCreateHclBody/Should_create_body_with_two_entries (0.00s)
PASS internal/app.TestCreateHclBody/Should_create_body_with_no_constraints (0.00s)
PASS internal/app.TestCreateHclBody (0.00s)
PASS internal/app.TestParseOutputLockfilePath/Should_return_default_path_if_empty (0.00s)
PASS internal/app.TestParseOutputLockfilePath/Should_return_path_if_not_empty (0.00s)
PASS internal/app.TestParseOutputLockfilePath (0.00s)
PASS internal/app.TestGetLockfile/Should_return_default_path_if_not_existent (0.00s)
PASS internal/app.TestGetLockfile/Should_return_path_if_existent (0.00s)
PASS internal/app.TestGetLockfile (0.00s)
PASS internal/app.TestParseHclLockfile/Should_parse_lockfile_with_no_constraints_field (0.00s)
PASS internal/app.TestParseHclLockfile/Should_parse_lockfile_with_all_fields (0.00s)
PASS internal/app.TestParseHclLockfile (0.00s)
PASS internal/app.TestIsTerraformPluginDirExistent/Should_return_true_if_TerraformPluginDir_exists (0.01s)
PASS internal/app.TestIsTerraformPluginDirExistent/Should_return_false_if_TerraformPluginDir_exists (0.01s)
PASS internal/app.TestIsTerraformPluginDirExistent (0.03s)
PASS internal/app.TestNew/Should_create_App_instance_with_correct_paths (0.01s)
PASS internal/app.TestNew (0.01s)
PASS internal/app.TestActivate/Should_activate_on_first_use_(no_directories_present) (0.02s)
PASS internal/app.TestActivate/Should_activate_if_Plugin_Backup_directory_is_present (0.01s)
PASS internal/app.TestActivate/Should_already_be_activated_if_Plugin_directory_is_present (0.01s)
PASS internal/app.TestActivate (0.04s)
PASS internal/app.TestDeactivate/Should_deactivate_on_first_use_(no_directories_present) (0.02s)
PASS internal/app.TestDeactivate/Should_deactivate_if_Plugin_directory_is_present (0.01s)
PASS internal/app.TestDeactivate/Should_already_be_deactivated_if_Plugin_Backup_directory_is_present (0.01s)
PASS internal/app.TestDeactivate (0.04s)
PASS internal/app.TestCheckStatus/Should_return_active_status (0.01s)
PASS internal/app.TestCheckStatus/Should_return_Deactivated_status (0.01s)
PASS internal/app.TestCheckStatus (0.03s)
PASS internal/app.TestListProviders/Should_return_no_output_for_fresh_install (0.01s)
PASS internal/app.TestListProviders/Should_return_correct_output_for_two_"installed"_providers (0.02s)
PASS internal/app.TestListProviders (0.03s)
coverage: 61.5% of statements
PASS internal/app

DONE 46 tests in 65.255s
```


## Which issue(s) does this PR fix?

<!--
fixes #
fixes #
-->
n/a