### PR TITLE
Docs/clarify go dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A CLI to help with managing the installation and compilation of terraform provid
   - [Table of Contents](#table-of-contents)
   - [Motivation](#motivation)
   - [Installation](#installation)
+    - [Dependencies](#dependencies)
   - [Usage](#usage)
     - [Debugging Installation Problems](#debugging-installation-problems)
     - [Terraform Lockfile handling](#terraform-lockfile-handling)
@@ -42,6 +43,14 @@ While using my new Macbook with M1 chip I often encountered issues in client pro
 ```sh
 brew install kreuzwerker/taps/m1-terraform-provider-helper
 ```
+
+### Dependencies
+
+Since Go is used to build the providers, you need to have a working Go setup in the local directory where you run m1-terraform-provider-helper
+commands. Although Go is installed by Homebrew as a dependency
+of m1-terraform-provider-helper, the Go binary won't necessarily be in your PATH. (For example, if you use
+asdf or a similar version manager for Go, the version manager's shim likely comes before Homebrew's Go
+binary in your PATH.) Ensure that the command `go version` succeeds before using this tool.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -62,21 +62,21 @@ binary in your PATH.) Ensure that the command `go version` succeeds before using
 ## Usage
 
 ```
-A CLI to manage the installation of Terraform providers for the Mac M1 chip
+A CLI to manage the installation of Terraform providers for an ARM-based Mac
 
 Usage:
   m1-terraform-provider-helper [command]
 
 Available Commands:
-  activate    Activate the usage of m1 provider helper
+  activate    Activate the m1-terraform-provider-helper
   completion  Generate the autocompletion script for the specified shell
-  deactivate  Deactivate the usage of M1 provider helper
+  deactivate  Deactivate the m1-terraform-provider-helper
   help        Help about any command
-  install     Downloads (and compiles) a Terraform provider for the M1 chip
-  list        Lists all available providers and their versions
+  install     Download (and compile) a Terraform provider for an ARM-based Mac
+  list        List all available providers and their versions
   lockfile    Commands to work with Terraform lockfiles
-  status      Shows the status of the m1 provider installations
-  version     Displays the current version
+  status      Show the status of the m1-terraform-provider-helper installation
+  version     Display the current version
 
 Flags:
   -h, --help   help for m1-terraform-provider-helper

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 # m1-terraform-provider-helper
 
 [![Release](https://img.shields.io/github/v/release/kreuzwerker/m1-terraform-provider-helper)](https://github.com/kreuzwerker/m1-terraform-provider-helper/releases)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kreuzwerker/m1-terraform-provider-helper/blob/main/LICENSE)  
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kreuzwerker/m1-terraform-provider-helper/blob/main/LICENSE)
 [![Go Status](https://github.com/kreuzwerker/m1-terraform-provider-helper/workflows/tests/badge.svg)](https://github.com/kreuzwerker/m1-terraform-provider-helper/actions)
 [![Lint Status](https://github.com/kreuzwerker/m1-terraform-provider-helper/workflows/golangci-lint/badge.svg)](https://github.com/kreuzwerker/m1-terraform-provider-helper/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/kreuzwerker/m1-terraform-provider-helper)](https://goreportcard.com/report/github.com/kreuzwerker/m1-terraform-provider-helper)  
+[![Go Report Card](https://goreportcard.com/badge/github.com/kreuzwerker/m1-terraform-provider-helper)](https://goreportcard.com/report/github.com/kreuzwerker/m1-terraform-provider-helper)
 
-A CLI to help with managing the installation and compilation of terraform providers when running a new M1 Mac. 
+A CLI to manage the installation and compilation of Terraform providers for an ARM-based Mac.
 
 ## Table of Contents
 
@@ -36,7 +36,14 @@ A CLI to help with managing the installation and compilation of terraform provid
   - [License](#license)
 ## Motivation
 
-While using my new Macbook with M1 chip I often encountered issues in client projects when working with Terraform projects. Either some terraform providers have no adapted to the new `darwin_arm64` at all or the version of the used provider is pinned to an older version. In both cases, there is no pre-compiled binary for `darwin_arm64` => you have to compile it yourself. There is a nice writeup on how to compile in a [Terraform Issue](https://github.com/hashicorp/terraform/issues/27257#issuecomment-754777716). As I am constantly switching forth and back between using own-compiled binaries and pre-build, I wanted to have an elegant solution which manages all the details by itself.
+While using my then-new MacBook with an M1 chip, I often encountered issues in client projects when
+working with Terraform. Some Terraform providers hadn't adapted to the new `darwin_arm64` architecture at
+all, or else the provider was pinned to an older, incompatible version. In both cases, there was no
+pre-compiled binary for `darwin_arm64`; you had to compile it yourself. (There's a nice write-up on how to
+compile in a
+[Terraform Issue](https://github.com/hashicorp/terraform/issues/27257#issuecomment-754777716).) As I was
+constantly switching back and forth between own-compiled binaries and pre-built ones, I wanted an elegant
+solution that managed all the details by itself.
 
 ## Installation
 
@@ -55,27 +62,30 @@ binary in your PATH.) Ensure that the command `go version` succeeds before using
 ## Usage
 
 ```
-A CLI to manage the installation of terraform providers for the Mac M1 chip
+A CLI to manage the installation of Terraform providers for the Mac M1 chip
 
 Usage:
   m1-terraform-provider-helper [command]
 
 Available Commands:
   activate    Activate the usage of m1 provider helper
+  completion  Generate the autocompletion script for the specified shell
   deactivate  Deactivate the usage of M1 provider helper
   help        Help about any command
-  install     Downloads (and compiles) a terraform provider for the M1 chip
+  install     Downloads (and compiles) a Terraform provider for the M1 chip
   list        Lists all available providers and their versions
-  lockfile    Commands to work with terraform lockfiles
+  lockfile    Commands to work with Terraform lockfiles
   status      Shows the status of the m1 provider installations
-  version     Display the current version
+  version     Displays the current version
 
 Flags:
   -h, --help   help for m1-terraform-provider-helper
+
+Use "m1-terraform-provider-helper [command] --help" for more information about a command.
 ```
 
 Example:
-You want to install the `terraform-provider-vault` in version `v2.10.0` because you are using it in a project and let's assume it has no pre-build binary for Mac M1:
+You want to install version `v2.10.0` of `terraform-provider-vault` because you're using it in a project. Let's assume it has no pre-built binary for an ARM-based Mac:
 
 ```sh
 m1-terraform-provider-helper activate # (In case you have not activated the helper)
@@ -106,7 +116,7 @@ checksums previously recorded in the dependency lock file.
 The reason is that the checksums inside the existing lockfile are the checksum of the previously installed `darwin_amd64` provider. Now we are using our own `darwin_arm64` compiled provider, which has a different checksum. In order to make `terraform init` work again, we have to add the checksum of the local provider to the lockfile.
 
 This is done via the `m1-terraform-provider-helper lockfile upgrade` command. It also two flags which you can use to specify the input/output lockfile:
-* `--input-lockfile-path` 
+* `--input-lockfile-path`
 * `--output-path`
 
 
@@ -175,7 +185,7 @@ If you want it automated prepend `TAG=1` to the command as follows:
 ```sh
 # TAG=1 indicates to tag and generate the changelog
 TAG=1 make minor
-git push origin main --tags 
+git push origin main --tags
 ```
 
 ## License

--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -8,7 +8,7 @@ import (
 func activateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "activate",
-		Short: "Activate the usage of m1 provider helper",
+		Short: "Activate the m1-terraform-provider-helper",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := app.New()

--- a/cmd/deactivate.go
+++ b/cmd/deactivate.go
@@ -8,7 +8,7 @@ import (
 func deactivateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deactivate",
-		Short: "Deactivate the usage of M1 provider helper",
+		Short: "Deactivate the m1-terraform-provider-helper",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := app.New()

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -18,8 +18,8 @@ func installCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install [providerName]",
 		Args:  cobra.ExactArgs(1),
-		Short: "Downloads (and compiles) a Terraform provider for the M1 chip",
-		Long:  "Download and compiles the specific Terraform provider for your M1 chip. Provider name is the Terraform registry identifier, e.g. \"hashicorp/aws\"",
+		Short: "Download (and compile) a Terraform provider for an ARM-based Mac",
+		Long:  "Download and compile a specific Terraform provider for an ARM-based Mac. Provider name is the Terraform registry identifier (e.g., \"hashicorp/aws\")",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := app.New()
 			a.Init()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -8,7 +8,7 @@ import (
 func listCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Lists all available providers and their versions",
+		Short: "List all available providers and their versions",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := app.New()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ import (
 func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "m1-terraform-provider-helper",
-		Short: "A CLI to manage the installation of Terraform providers for the Mac M1 chip",
+		Short: "A CLI to manage the installation of Terraform providers for an ARM-based Mac",
 	}
 
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -8,7 +8,7 @@ import (
 func statusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Shows the status of the m1 provider installations",
+		Short: "Show the status of the m1-terraform-provider-helper installation",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := app.New()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,7 +12,7 @@ const version string = "0.8.2"
 func versionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Displays the current version",
+		Short: "Display the current version",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stdout, "Current version: %s", version)


### PR DESCRIPTION
This PR hopefully resolves any ambiguity about satisfying the Go dependency for this tool, as brought up in #134. It also makes some other small edits to the docs and command descriptions.

## What does this do / why do we need it?

Installing `m1-terraform-provider-helper` via Homebrew also installs Go as a dependency, but it doesn't ensure that the Go installation is working. Since a working Go configuration is a requirement for using the tool, this PR clarifies the nature of the dependency and how to satisfy it.

## How this PR fixes the problem?

By adding a sub-section (`Installation > Dependencies`) to the README.

## What should your reviewer look out for in this PR?

How clear is the proposed wording? Does it fit with the existing style? Is a version bump supposed to be included as well?

## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)

## Additional Comments (if any)

Please consider the two `docs` commits entirely optional. Here's what I did:
- Replaced the `Usage` code block to show the actual current output
- Replaced references to M! with ARM, since this tool is also helpful for M2 and (probably soon) M3 Macs
- Fixed a few typos, standardized capitalization, and made a few other subjective style improvements

## Which issue(s) does this PR fix?

fixes #134 