### PR TITLE
Support XDG spec for providers cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ bin
 # End of https://www.toptal.com/developers/gitignore/api/go
 
 ## IDEs
+.idea
 .vscode

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kreuzwerker/m1-terraform-provider-helper
 go 1.19
 
 require (
+	github.com/adrg/xdg v0.4.0
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.17.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20230518184743-7afd39499903 h1:ZK3C5DtzV2
 github.com/ProtonMail/go-crypto v0.0.0-20230518184743-7afd39499903/go.mod h1:8TI4H3IbrackdNgv+92dI+rhpCaLqM0IfpgCgenFvRE=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
@@ -119,6 +121,7 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,12 +29,9 @@ type Config struct {
 }
 
 const (
-	DefaultProvidersCacheDir        = "/.m1-terraform-provider-helper"
-	DefaultTerraformPluginDir       = "/.terraform.d/plugins"
-	DefaultTerraformPluginBackupDir = "/.terraform.d/plugins_backup"
-	DefaultTerraformRegistryURL     = "https://registry.terraform.io/v1/providers/"
-	FileModePerm                    = 0777
-	DefaultRequestTimeoutInSeconds  = 10
+	DefaultTerraformRegistryURL    = "https://registry.terraform.io/v1/providers/"
+	FileModePerm                   = 0777
+	DefaultRequestTimeoutInSeconds = 10
 )
 
 func New() *App {
@@ -47,10 +44,10 @@ func New() *App {
 		Config: &Config{
 			BaseDir:                  BaseDir,
 			GoPath:                   GetCurrentGoPath(),
-			TerraformPluginDir:       BaseDir + DefaultTerraformPluginDir,
-			TerraformPluginBackupDir: BaseDir + DefaultTerraformPluginBackupDir,
-			ProvidersCacheDir:        BaseDir + DefaultProvidersCacheDir,
-			TerraformRegistryURL:     DefaultTerraformRegistryURL,
+			TerraformPluginDir:       GetTerraformPluginsPath(BaseDir),
+			TerraformPluginBackupDir: GetTerraformPluginsBackupPath(BaseDir),
+			ProvidersCacheDir:        GetProvidersCachePath(BaseDir),
+			TerraformRegistryURL:     GetTerraformRegistryURL(),
 		},
 		Out: os.Stdout,
 	}

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -1,9 +1,13 @@
 package app
 
 import (
+	"fmt"
 	"go/build"
+	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/adrg/xdg"
 )
 
 func GetCurrentGoPath() string {
@@ -21,4 +25,37 @@ func GetCurrentGoPath() string {
 	}
 
 	return path
+}
+
+func GetTerraformPluginsPath(baseDir string) string {
+	return getTerraformDataPath(baseDir) + "/plugins"
+}
+
+func GetTerraformPluginsBackupPath(baseDir string) string {
+	return getTerraformDataPath(baseDir) + "/plugins_backup"
+}
+
+func GetProvidersCachePath(baseDir string) string {
+	relPath := "m1-terraform-provider-helper"
+	cacheDirPath, err := xdg.SearchCacheFile(relPath)
+	if err != nil {
+		return fmt.Sprintf("%s/.%s", baseDir, relPath)
+	}
+	return cacheDirPath
+}
+
+func GetTerraformRegistryURL() string {
+	registryURL, ok := os.LookupEnv("TF_HELPER_REGISTRY_URL")
+	if !ok {
+		return DefaultTerraformRegistryURL
+	}
+	return registryURL
+}
+
+func getTerraformDataPath(baseDir string) string {
+	dataDirPath, err := xdg.SearchDataFile("terraform")
+	if err != nil {
+		dataDirPath = baseDir + "/.terraform.d"
+	}
+	return dataDirPath
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to m1-terraform-provider-helper! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

Allow to place providers cache by XDG spec, like `${XDG_CACHE_HOME}/m1-terraform-provider-helper/` with fallback to current default `${HOME}/.m1-terraform-provider-helper/`


## How this PR fixes the problem?

On app configuration init, searching for existing directory via [xdg.SearchCacheFile](https://pkg.go.dev/github.com/adrg/xdg#SearchCacheFile) and if `${XDG_CACHE_HOME}/m1-terraform-provider-helper/` not found, fallback to `${HOME}/.m1-terraform-provider-helper/`


## What should your reviewer look out for in this PR?

Terraform itself still doesn't support XDG spec, so `xdg.SearchDataFile("terraform")` probably will always return error, but this allows to use custom terraform build or tofu.


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

{Please write here}


## Which issue(s) does this PR fix?

<!--
fixes #
fixes #
-->
